### PR TITLE
Added shrinkPlayer() functionality, added separate variable for npc dimensions. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html>
     <head>
         <meta charset="utf-8">
-            <title>Game</title>
-            <link rel = "stylesheet" type = "text/css" href = "styles.css" />
+            <title>runaway</title>
+            <link rel="stylesheet" type="text/css" href="styles.css" />
         </head>
         <body>
-            <canvas id = "mainCanvas" width = "500" height = "400"></canvas>
-            <script src = "script.js"></script>
+            <canvas id="mainCanvas" width="500" height="400"></canvas>
+            <script src="script.js"></script>
         </body>
     </html>

--- a/script.js
+++ b/script.js
@@ -256,7 +256,7 @@ function render() {
     makeScore(score);
     updateHScore();
     makeHighScore();
-
+    shrinkPlayer(score);
 }
 
 
@@ -276,7 +276,6 @@ function update() {
     if (collisionRect(npc, npc2)) {
         processEaster();
     }
-    shrinkPlayer(score);
     quadrantRun(player, npc);
     quadrantChase(player, npc2);
 }

--- a/script.js
+++ b/script.js
@@ -16,32 +16,58 @@ var touches = {
 var width = canvas.width;
 var speed = width * 0.005;
 var height = canvas.height;
-var characterheight = width * 0.03;
-var characterwidth = width * 0.03;
+
+var characterHeight = width * 0.03;
+var characterWidth = width * 0.03;
+var npcCharacterHeight = width * 0.03;
+var npcCharacterWidth = width * 0.03;
+
+var player = {
+    x: 40,
+    y: 40,
+    width: characterWidth,
+    height: characterHeight
+};
+
+
+function shrinkPlayer(score) {
+    if (score >= 0 && score < 35) {
+        characterHeight = width * 0.03 * ((100-(2*score))/100);
+        characterWidth = width * 0.03 * ((100-(2*score))/100);
+        player.height = characterHeight;
+        player.width = characterWidth;
+    } else if (score >= 0 && score < 70) {
+        npcCharacterHeight = width * 0.03 * ((100-(2*(score-35)))/100);
+        npcCharacterWidth = width * 0.03 * ((100-(2*(score-35)))/100);
+        npc.height = npcCharacterHeight;
+        npc.width = npcCharacterWidth;
+    } else {
+        player.height = characterHeight;
+        player.width = characterWidth;
+        npc.height = npcCharacterHeight;
+        npc.width = npcCharacterWidth;
+    }
+}
+
 
 var score = 0;
 var uncertainty = 0.1;
 var fontsize = 32;
 var highscore = 0;
 
-var player = {
-        x: 40,
-        y: 40,
-        width: characterwidth,
-        height: characterheight
-    };
-        
+
 var npc = {
-        x: Math.random() * (width - characterwidth),
-        y: Math.random() * (height - characterheight),
-        width: characterwidth,
-        height: characterheight
+        x: Math.random() * (width - npcCharacterWidth),
+        y: Math.random() * (height - npcCharacterHeight),
+        width: npcCharacterWidth,
+        height: npcCharacterHeight
     };
+
 var npc2 = {
-        x: Math.random() * (width - characterwidth),
-        y: Math.random() * (height - characterheight),
-        width: characterwidth,
-        height: characterheight
+        x: Math.random() * (width - characterWidth),
+        y: Math.random() * (height - characterHeight),
+        width: characterWidth,
+        height: characterHeight
     };
 
 window.addEventListener("keydown", function (e) {
@@ -214,20 +240,11 @@ function collisionRect(first, second) {
     first.y + first.height < second.y);
 }
 
-/*function shrinkPlayer() {
-        if (score > 2) {
-                player = {player.x, player.y, width: characterwidth * 0.75, height: characterheight * 0.75}
-        } else {
-                player = {player.x, player.y, width: characterwidth, height: characterheight}
-        }
-}*/
-
 function updateHScore() {
     "use strict";
     if (score > highscore) {
         highscore = score;
     };
-    //shrinkPlayer();
 }
 
 function render() {
@@ -239,6 +256,7 @@ function render() {
     makeScore(score);
     updateHScore();
     makeHighScore();
+
 }
 
 
@@ -258,6 +276,7 @@ function update() {
     if (collisionRect(npc, npc2)) {
         processEaster();
     }
+    shrinkPlayer(score);
     quadrantRun(player, npc);
     quadrantChase(player, npc2);
 }


### PR DESCRIPTION
Added shrinkPlayer() functionality to shrink player as score increases, and shrink npc as score increases beyond limit of player shrinkage. Current limits are: player gradually shrinks to 30% size when score is in range [0,35], and npc shrinks to 30% size when score is between [36,70]. Beyond score of 70, no change in size should occur...hopefully.
